### PR TITLE
change version, fix typo and append `DEFAULT_AUTO_MOCK_SUCCESS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ import pytest
 
 from bot import echo
 
-from aiogram_tests import MockedBot
+from aiogram_tests import MockedRequester
 from aiogram_tests.handler import MessageHandler
 from aiogram_tests.types.dataset import MESSAGE
 
 
 @pytest.mark.asyncio
 async def test_echo():
-    request = MockedBot(MessageHandler(echo))
+    request = MockedRequester(MessageHandler(echo))
     calls = await request.query(message=MESSAGE.as_object(text="Hello, Bot!"))
     answer_message = calls.send_message.fetchone()
     assert answer_message.text == "Hello, Bot!"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from aiogram_tests.types.dataset import MESSAGE
 async def test_echo():
     request = MockedBot(MessageHandler(echo))
     calls = await request.query(message=MESSAGE.as_object(text="Hello, Bot!"))
-    answer_message = calls.send_messsage.fetchone()
+    answer_message = calls.send_message.fetchone()
     assert answer_message.text == "Hello, Bot!"
 
 ```

--- a/aiogram_tests/__init__.py
+++ b/aiogram_tests/__init__.py
@@ -1,4 +1,4 @@
 from .requester import MockedBot
 
 __all__ = ["MockedBot"]
-__version__ = "1.0.1"
+__version__ = "1.0.4"

--- a/aiogram_tests/__init__.py
+++ b/aiogram_tests/__init__.py
@@ -3,4 +3,3 @@ from .requester import MockedBot
 __all__ = ["MockedBot"]
 __version__ = "1.0.4"
 
-DEFAULT_AUTO_MOCK_SUCCESS = True

--- a/aiogram_tests/__init__.py
+++ b/aiogram_tests/__init__.py
@@ -1,5 +1,5 @@
-from .requester import MockedBot
+from .requester import MockedRequester
 
-__all__ = ["MockedBot"]
+__all__ = ["MockedRequester"]
 __version__ = "1.0.4"
 

--- a/aiogram_tests/__init__.py
+++ b/aiogram_tests/__init__.py
@@ -2,3 +2,5 @@ from .requester import MockedBot
 
 __all__ = ["MockedBot"]
 __version__ = "1.0.4"
+
+DEFAULT_AUTO_MOCK_SUCCESS = True

--- a/aiogram_tests/handler/base.py
+++ b/aiogram_tests/handler/base.py
@@ -14,7 +14,7 @@ from aiogram.methods.base import TelegramType
 from aiogram.types import Chat
 from aiogram.types import User
 
-from aiogram_tests.mocked_bot import MockedBot
+from aiogram_tests.mocked_bot import MockedRequester
 from aiogram_tests.mocked_bot import DEFAULT_AUTO_MOCK_SUCCESS
 from aiogram_tests.types.dataset import CHAT
 from aiogram_tests.types.dataset import USER
@@ -29,7 +29,7 @@ class RequestHandler:
         dp: Optional[Dispatcher] = None,
         **kwargs,
     ):
-        self.bot = MockedBot(auto_mock_success=auto_mock_success)
+        self.bot = MockedRequester(auto_mock_success=auto_mock_success)
         if dp is None:
             dp = Dispatcher(storage=MemoryStorage())
         self.dp = dp

--- a/aiogram_tests/handler/base.py
+++ b/aiogram_tests/handler/base.py
@@ -14,7 +14,7 @@ from aiogram.methods.base import TelegramType
 from aiogram.types import Chat
 from aiogram.types import User
 
-from aiogram_tests.mocked_bot import MockedRequester
+from aiogram_tests.mocked_bot import MockedBot
 from aiogram_tests.mocked_bot import DEFAULT_AUTO_MOCK_SUCCESS
 from aiogram_tests.types.dataset import CHAT
 from aiogram_tests.types.dataset import USER
@@ -29,7 +29,7 @@ class RequestHandler:
         dp: Optional[Dispatcher] = None,
         **kwargs,
     ):
-        self.bot = MockedRequester(auto_mock_success=auto_mock_success)
+        self.bot = MockedBot(auto_mock_success=auto_mock_success)
         if dp is None:
             dp = Dispatcher(storage=MemoryStorage())
         self.dp = dp

--- a/aiogram_tests/handler/base.py
+++ b/aiogram_tests/handler/base.py
@@ -14,6 +14,7 @@ from aiogram.methods.base import TelegramType
 from aiogram.types import Chat
 from aiogram.types import User
 
+from aiogram_tests import DEFAULT_AUTO_MOCK_SUCCESS
 from aiogram_tests.mocked_bot import MockedBot
 from aiogram_tests.types.dataset import CHAT
 from aiogram_tests.types.dataset import USER
@@ -24,7 +25,7 @@ class RequestHandler:
         self,
         dp_middlewares: Iterable[BaseMiddleware] = None,
         exclude_observer_methods: Iterable[str] = None,
-        auto_mock_success: bool = False,
+        auto_mock_success: bool = DEFAULT_AUTO_MOCK_SUCCESS,
         dp: Optional[Dispatcher] = None,
         **kwargs,
     ):

--- a/aiogram_tests/handler/base.py
+++ b/aiogram_tests/handler/base.py
@@ -14,8 +14,8 @@ from aiogram.methods.base import TelegramType
 from aiogram.types import Chat
 from aiogram.types import User
 
-from aiogram_tests import DEFAULT_AUTO_MOCK_SUCCESS
 from aiogram_tests.mocked_bot import MockedBot
+from aiogram_tests.mocked_bot import DEFAULT_AUTO_MOCK_SUCCESS
 from aiogram_tests.types.dataset import CHAT
 from aiogram_tests.types.dataset import USER
 

--- a/aiogram_tests/handler/handler.py
+++ b/aiogram_tests/handler/handler.py
@@ -27,9 +27,6 @@ class TelegramEventObserverHandler(RequestHandler):
     ):
         super().__init__(dp_middlewares, exclude_observer_methods, **kwargs)
 
-        if state_context:
-            assert not state and not state_data
-
         self._callback = callback
         self._filters: List = list(filters)
         self._state: Union[State, str, None] = state
@@ -54,15 +51,7 @@ class TelegramEventObserverHandler(RequestHandler):
 
         self.register_handler()
 
-        if self._state_context:
-            new_state = await self._state_context.get_state()
-            new_state_data = await self._state_context.get_data()
-
-            old_state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
-            await old_state.set_state(new_state)
-            await old_state.update_data(**new_state_data)
-
-        if self._state and not self._state_context:
+        if self._state_context or self._state:
             state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
             await state.set_state(self._state)
             await state.update_data(**self._state_data)

--- a/aiogram_tests/handler/handler.py
+++ b/aiogram_tests/handler/handler.py
@@ -55,12 +55,10 @@ class TelegramEventObserverHandler(RequestHandler):
         self.register_handler()
 
         if self._state_context:
-            old_state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
-            old_state.set_state()
-
             new_state = await self._state_context.get_state()
             new_state_data = await self._state_context.get_data()
 
+            old_state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
             await old_state.set_state(new_state)
             await old_state.update_data(**new_state_data)
 

--- a/aiogram_tests/handler/handler.py
+++ b/aiogram_tests/handler/handler.py
@@ -15,15 +15,15 @@ from .base import RequestHandler
 
 class TelegramEventObserverHandler(RequestHandler):
     def __init__(
-        self,
-        callback: Callable,
-        *filters: Filter,
-        state: Union[State, str, None] = None,
-        state_data: Dict = None,
-        state_context: Union[FSMContext, None] = None,
-        dp_middlewares: Iterable = None,
-        exclude_observer_methods: Iterable = None,
-        **kwargs,
+            self,
+            callback: Callable,
+            *filters: Filter,
+            state: Union[State, str, None] = None,
+            state_data: Dict = None,
+            state_context: Union[FSMContext, None] = None,
+            dp_middlewares: Iterable = None,
+            exclude_observer_methods: Iterable = None,
+            **kwargs,
     ):
         super().__init__(dp_middlewares, exclude_observer_methods, **kwargs)
 
@@ -38,7 +38,8 @@ class TelegramEventObserverHandler(RequestHandler):
 
         if self._state_context:
             self._state_context = state_context
-        elif self._state_data is None:
+
+        if self._state_data is None:
             self._state_data = {}
 
         if self._filters is None:
@@ -52,6 +53,16 @@ class TelegramEventObserverHandler(RequestHandler):
             self._filters.append(StateFilter(self._state))
 
         self.register_handler()
+
+        if self._state_context:
+            old_state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
+            old_state.set_state()
+
+            new_state = await self._state_context.get_state()
+            new_state_data = await self._state_context.get_data()
+
+            await old_state.set_state(new_state)
+            await old_state.update_data(**new_state_data)
 
         if self._state and not self._state_context:
             state = self.dp.fsm.get_context(self.bot, user_id=12345678, chat_id=12345678)
@@ -89,3 +100,4 @@ class CallbackQueryHandler(TelegramEventObserverHandler):
 
     async def feed_update(self, callback_query: types.CallbackQuery, *args, **kwargs) -> None:
         await self.dp.feed_update(self.bot, types.Update(update_id=12345678, callback_query=callback_query))
+

--- a/aiogram_tests/mocked_bot.py
+++ b/aiogram_tests/mocked_bot.py
@@ -54,7 +54,7 @@ class MockedSession(BaseSession):
         yield b""
 
 
-class MockedRequester(Bot):
+class MockedBot(Bot):
     def __init__(self, auto_mock_success: bool = DEFAULT_AUTO_MOCK_SUCCESS, **kwargs):
         super().__init__(kwargs.pop("token", "42:TEST"), session=MockedSession(), **kwargs)
         self.session = MockedSession()

--- a/aiogram_tests/mocked_bot.py
+++ b/aiogram_tests/mocked_bot.py
@@ -54,7 +54,7 @@ class MockedSession(BaseSession):
         yield b""
 
 
-class MockedBot(Bot):
+class MockedRequester(Bot):
     def __init__(self, auto_mock_success: bool = DEFAULT_AUTO_MOCK_SUCCESS, **kwargs):
         super().__init__(kwargs.pop("token", "42:TEST"), session=MockedSession(), **kwargs)
         self.session = MockedSession()

--- a/aiogram_tests/mocked_bot.py
+++ b/aiogram_tests/mocked_bot.py
@@ -15,6 +15,8 @@ from aiogram.types import ResponseParameters
 from aiogram.types import UNSET
 from aiogram.types import User
 
+from aiogram_tests import DEFAULT_AUTO_MOCK_SUCCESS
+
 
 class MockedSession(BaseSession):
     def __init__(self):
@@ -52,7 +54,7 @@ class MockedSession(BaseSession):
 
 
 class MockedBot(Bot):
-    def __init__(self, auto_mock_success=False, **kwargs):
+    def __init__(self, auto_mock_success: bool = DEFAULT_AUTO_MOCK_SUCCESS, **kwargs):
         super().__init__(kwargs.pop("token", "42:TEST"), session=MockedSession(), **kwargs)
         self.session = MockedSession()
         self._me = User(
@@ -88,9 +90,9 @@ class MockedBot(Bot):
         self.session.add_result(response)
         return response
 
-    async def __call__(self, method: Type[TelegramMethod[TelegramType]], request_timeout: Optional[int] = None):
+    async def __call__(self, method: TelegramMethod, request_timeout: Optional[int] = None):
         if self.auto_mock_success:
-            self.add_result_for(method, ok=True)
+            self.add_result_for(method.__class__, ok=True)
         return await super().__call__(method, request_timeout)
 
     def get_request(self) -> Request:

--- a/aiogram_tests/mocked_bot.py
+++ b/aiogram_tests/mocked_bot.py
@@ -15,7 +15,8 @@ from aiogram.types import ResponseParameters
 from aiogram.types import UNSET
 from aiogram.types import User
 
-from aiogram_tests import DEFAULT_AUTO_MOCK_SUCCESS
+
+DEFAULT_AUTO_MOCK_SUCCESS = True
 
 
 class MockedSession(BaseSession):

--- a/aiogram_tests/requester.py
+++ b/aiogram_tests/requester.py
@@ -43,7 +43,7 @@ class Calls:
             )
 
 
-class MockedBot:
+class MockedRequester:
     def __init__(self, request_handler: RequestHandler):
         self._handler: RequestHandler = request_handler
 

--- a/examples/example_tests.py
+++ b/examples/example_tests.py
@@ -9,7 +9,7 @@ from test_bot import message_handler_with_state_data
 from test_bot import States
 from test_bot import TestCallbackData
 
-from aiogram_tests import MockedBot
+from aiogram_tests import MockedRequester
 from aiogram_tests.handler import CallbackQueryHandler
 from aiogram_tests.handler import MessageHandler
 from aiogram_tests.types.dataset import CALLBACK_QUERY
@@ -18,7 +18,7 @@ from aiogram_tests.types.dataset import MESSAGE
 
 @pytest.mark.asyncio
 async def test_message_handler():
-    requester = MockedBot(MessageHandler(message_handler))
+    requester = MockedRequester(MessageHandler(message_handler))
     calls = await requester.query(MESSAGE.as_object(text="Hello!"))
     answer_message = calls.send_message.fetchone().text
     assert answer_message == "Hello!"
@@ -26,7 +26,7 @@ async def test_message_handler():
 
 @pytest.mark.asyncio
 async def test_command_handler():
-    requester = MockedBot(MessageHandler(command_handler, Command(commands=["start"])))
+    requester = MockedRequester(MessageHandler(command_handler, Command(commands=["start"])))
     calls = await requester.query(MESSAGE.as_object(text="/start"))
     answer_message = calls.send_message.fetchone().text
     assert answer_message == "Hello, new user!"
@@ -34,7 +34,7 @@ async def test_command_handler():
 
 @pytest.mark.asyncio
 async def test_message_handler_with_state():
-    requester = MockedBot(MessageHandler(message_handler_with_state, state=States.state))
+    requester = MockedRequester(MessageHandler(message_handler_with_state, state=States.state))
     calls = await requester.query(MESSAGE.as_object(text="Hello, bot!"))
     answer_message = calls.send_message.fetchone().text
     assert answer_message == "Hello, from state!"
@@ -42,7 +42,7 @@ async def test_message_handler_with_state():
 
 @pytest.mark.asyncio
 async def test_callback_query_handler():
-    requester = MockedBot(CallbackQueryHandler(callback_query_handler, TestCallbackData.filter()))
+    requester = MockedRequester(CallbackQueryHandler(callback_query_handler, TestCallbackData.filter()))
 
     callback_query = CALLBACK_QUERY.as_object(
         data=TestCallbackData(id=1, name="John").pack(), message=MESSAGE.as_object(text="Hello world!")
@@ -63,7 +63,7 @@ async def test_callback_query_handler():
 
 @pytest.mark.asyncio
 async def test_callback_query_handler_with_state():
-    requester = MockedBot(CallbackQueryHandler(callback_query_handler_with_state, TestCallbackData.filter()))
+    requester = MockedRequester(CallbackQueryHandler(callback_query_handler_with_state, TestCallbackData.filter()))
 
     callback_query = CALLBACK_QUERY.as_object(data=TestCallbackData(id=1, name="John").pack())
     calls = await requester.query(callback_query)
@@ -74,7 +74,7 @@ async def test_callback_query_handler_with_state():
 
 @pytest.mark.asyncio
 async def test_handler_with_state_data():
-    requester = MockedBot(
+    requester = MockedRequester(
         MessageHandler(
             message_handler_with_state_data, state=States.state_1, state_data={"info": "this is message handler"}
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["aiogram ~= 3.0.0b7", "setuptools"]
 
 [project]
 name = "aiogram_tests"
-version = "1.0.2"
+version = "1.0.4"
 authors = [
     { name = "Timur", email = "pavlov.timur556@yandex.ru" }
 ]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -13,7 +13,7 @@ from .bot import message_handler_with_state
 from .bot import message_handler_with_state_data
 from .bot import States
 from .bot import TestCallbackData
-from aiogram_tests import MockedBot
+from aiogram_tests.requester import MockedRequester
 from aiogram_tests.handler import CallbackQueryHandler
 from aiogram_tests.handler import MessageHandler
 from aiogram_tests.types.dataset import CALLBACK_QUERY
@@ -22,7 +22,7 @@ from aiogram_tests.types.dataset import MESSAGE
 
 @pytest.mark.asyncio
 async def test_message_handler():
-    requester = MockedBot(request_handler=MessageHandler(message_handler, auto_mock_success=True))
+    requester = MockedRequester(request_handler=MessageHandler(message_handler, auto_mock_success=True))
     calls = await requester.query(MESSAGE.as_object(text="Hello!"))
     answer_message = calls.send_message.fetchone().text
     assert answer_message == "Hello!"
@@ -30,7 +30,7 @@ async def test_message_handler():
 
 @pytest.mark.asyncio
 async def test_command_handler():
-    requester = MockedBot(request_handler=MessageHandler(command_handler, Command(commands=["start"])))
+    requester = MockedRequester(request_handler=MessageHandler(command_handler, Command(commands=["start"])))
     requester.add_result_for(SendMessage, ok=True)
     calls = await requester.query(MESSAGE.as_object(text="/start"))
     answer_message = calls.send_message.fetchone().text
@@ -39,7 +39,7 @@ async def test_command_handler():
 
 @pytest.mark.asyncio
 async def test_message_handler_with_state():
-    requester = MockedBot(request_handler=MessageHandler(message_handler_with_state, state=States.state))
+    requester = MockedRequester(request_handler=MessageHandler(message_handler_with_state, state=States.state))
     requester.add_result_for(SendMessage, ok=True)
     calls = await requester.query(MESSAGE.as_object(text="Hello, bot!"))
     answer_message = calls.send_message.fetchone().text
@@ -48,7 +48,7 @@ async def test_message_handler_with_state():
 
 @pytest.mark.asyncio
 async def test_callback_query_handler():
-    requester = MockedBot(request_handler=CallbackQueryHandler(callback_query_handler, TestCallbackData.filter()))
+    requester = MockedRequester(request_handler=CallbackQueryHandler(callback_query_handler, TestCallbackData.filter()))
     requester.add_result_for(AnswerCallbackQuery, ok=True)
     requester.add_result_for(SendMessage, ok=True)
 
@@ -73,7 +73,7 @@ async def test_callback_query_handler():
 
 @pytest.mark.asyncio
 async def test_callback_query_handler_with_state():
-    requester = MockedBot(
+    requester = MockedRequester(
         request_handler=CallbackQueryHandler(callback_query_handler_with_state, TestCallbackData.filter())
     )
 
@@ -89,7 +89,7 @@ async def test_callback_query_handler_with_state():
 
 @pytest.mark.asyncio
 async def test_handler_with_state_data():
-    requester = MockedBot(
+    requester = MockedRequester(
         request_handler=MessageHandler(
             message_handler_with_state_data, state=States.state_1, state_data={"info": "this is message handler"}
         )
@@ -103,7 +103,7 @@ async def test_handler_with_state_data():
 
 @pytest.mark.asyncio
 async def test_handler_with_fail():
-    requester = MockedBot(request_handler=MessageHandler(foo_command_handler, dp=dp))
+    requester = MockedRequester(request_handler=MessageHandler(foo_command_handler, dp=dp))
 
     requester.add_result_for(SendMessage, ok=False, description="Have no rights to send a message", error_code=401)
     requester.add_result_for(SendMessage, ok=True)

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -4,7 +4,7 @@ from aiogram_tests.exceptions import MethodIsNotCalledError
 from aiogram_tests.handler import MessageHandler
 from aiogram_tests.requester import Calls
 from aiogram_tests.requester import CallsList
-from aiogram_tests.requester import MockedBot
+from aiogram_tests.requester import MockedRequester
 from aiogram_tests.types.dataset import MESSAGE
 
 
@@ -28,7 +28,7 @@ async def test_requester():
         pass
 
     request_handler = MessageHandler(callback)
-    requester = MockedBot(request_handler=request_handler)
+    requester = MockedRequester(request_handler=request_handler)
     calls = await requester.query(message=MESSAGE.as_object(text="Hello world!"))
     assert isinstance(calls, Calls)
     with pytest.raises(MethodIsNotCalledError):


### PR DESCRIPTION
- With this [PR](https://github.com/OCCCAS/aiogram_tests/pull/11#issuecomment-1585652014) was implemented `auto_mock_success` flag. `False` default value break tests in `./examples/example_tests.py`. Example from `README.md` [are not working](https://github.com/OCCCAS/aiogram_tests/issues/16)
- Changed version number to `1.0.4` 
- Fixed typo in `README.md`

Be careful, it's my **first PR** ever :) I ran tests in `tests` and `./examples/example_tests.py`